### PR TITLE
Adding shunt and modulation config settings

### DIFF
--- a/Data/Scripts/DefenseShields/API/TapiBackend.cs
+++ b/Data/Scripts/DefenseShields/API/TapiBackend.cs
@@ -376,8 +376,8 @@ namespace DefenseShields
 
             var hitShuntedSide = shuntedFaceHit != -1;
             var shuntedFaces = Math.Abs(logic.ShieldRedirectState.X) + Math.Abs(logic.ShieldRedirectState.Y) + Math.Abs(logic.ShieldRedirectState.Z);
-            var shuntMod = !hitShuntedSide ? 1 - (shuntedFaces * Session.ShieldShuntBonus) : logic.DsSet.Settings.AutoManage ? 1 - Session.ShieldShuntBonus : 1f;
-            var preventBypassMod = MathHelper.Clamp(shuntedFaces * Session.ShieldBypassBonus, 0f, 1f);
+            var shuntMod = !hitShuntedSide ? 1 - (shuntedFaces * Session.Enforced.ShuntBonusResistance) : logic.DsSet.Settings.AutoManage ? 1 - Session.Enforced.ShuntBonusResistance : 1f;
+            var preventBypassMod = MathHelper.Clamp(shuntedFaces * Session.Enforced.ShuntPenResistance, 0f, 1f);
 
             var reinforcedPercent = hitShuntedSide ? logic.DsState.State.ShieldPercent + (shuntedFaces * 8) : logic.DsState.State.ShieldPercent;
             var heatedEnforcedPercent = reinforcedPercent / (1 + (logic.DsState.State.Heat * 0.005));
@@ -408,7 +408,7 @@ namespace DefenseShields
                 penChance = (float)((a * Math.Pow(x, 2)) + (b * x) + c);
             }
 
-            return new MyTuple<bool, int, int, float, float, float>(false, 0, 0, logic.DsSet.Settings.AutoManage ? 1 - Session.ShieldShuntBonus : 1f, 0, penChance);
+            return new MyTuple<bool, int, int, float, float, float>(false, 0, 0, logic.DsSet.Settings.AutoManage ? 1 - Session.Enforced.ShuntBonusResistance : 1f, 0, penChance);
         }
 
         private static float? TAPI_PointAttackShieldCon(IMyTerminalBlock block, Vector3D pos, long attackerId, float damage, float secondaryDamage, bool energy, bool drawParticle, bool posMustBeInside = false) //inlined for performance

--- a/Data/Scripts/DefenseShields/Config/SerializedValues.cs
+++ b/Data/Scripts/DefenseShields/Config/SerializedValues.cs
@@ -33,6 +33,9 @@
         [ProtoMember(23), DefaultValue(-1)] public float MinHP = -1f;
         [ProtoMember(24), DefaultValue(-1)] public float MaxRecharge = -1f;
         [ProtoMember(25), DefaultValue(-1)] public float MinRecharge = -1f;
+        [ProtoMember(26), DefaultValue(-1)] public float ShuntBonusResistance = -1f;
+        [ProtoMember(27), DefaultValue(-1)] public float ShuntPenResistance = -1f;
+        [ProtoMember(28), DefaultValue(-1)] public float MaxModulation = -1f;
     }
 
     [ProtoContract]

--- a/Data/Scripts/DefenseShields/Control/ModUi.cs
+++ b/Data/Scripts/DefenseShields/Control/ModUi.cs
@@ -71,7 +71,7 @@ namespace DefenseShields
         internal static void SetDamage(IMyTerminalBlock block, float newValue)
         {
             var comp = block?.GameLogic?.GetAs<Modulators>();
-            if (comp == null || newValue > 200 || newValue < -200) return;
+            if (comp == null || newValue > Session.Enforced.MaxModulation || newValue < -Session.Enforced.MaxModulation) return;
 
             if (Session.Instance.IsServer) 
                 ComputeDamage(comp, newValue);

--- a/Data/Scripts/DefenseShields/SupportClasses/StaticUtils.cs
+++ b/Data/Scripts/DefenseShields/SupportClasses/StaticUtils.cs
@@ -32,7 +32,7 @@ namespace DefenseShields.Support
             const int DisableEntityBarrier = 0;
             const int Debug = 1;
             const int SuperWeapons = 1;
-            const int Version = 92;
+            const int Version = 93;
             const float BlockScaler = 1f;
             const float PowerScaler = 1f;
             const float SizeScaler = 7.5f;
@@ -46,6 +46,9 @@ namespace DefenseShields.Support
             const float MinHP = 0f;
             const float MaxRecharge = float.MaxValue;
             const float MinRecharge = 0f;
+            const float ShuntBonusResistance = 0.16f;
+            const float ShuntPenResistance = 0.2f;
+            const float MaxModulation = 200f;
 
             var dsCfgExists = MyAPIGateway.Utilities.FileExistsInGlobalStorage("DefenseShields.cfg");
             if (dsCfgExists)
@@ -92,6 +95,15 @@ namespace DefenseShields.Support
                 Session.Enforced.MinHP = !unPackedData.MinHP.Equals(-1) ? unPackedData.MinHP : MinHP;
                 Session.Enforced.MaxRecharge = !unPackedData.MaxRecharge.Equals(-1) ? unPackedData.MaxRecharge : MaxRecharge;
                 Session.Enforced.MinRecharge = !unPackedData.MinRecharge.Equals(-1) ? unPackedData.MinRecharge : MinRecharge;
+                Session.Enforced.ShuntBonusResistance = !unPackedData.ShuntBonusResistance.Equals(-1f) ? unPackedData.ShuntBonusResistance : ShuntBonusResistance;
+                Session.Enforced.ShuntPenResistance = !unPackedData.ShuntPenResistance.Equals(-1f) ? unPackedData.ShuntPenResistance : ShuntPenResistance;
+                Session.Enforced.MaxModulation = !unPackedData.MaxModulation.Equals(-1f) ? unPackedData.MaxModulation : MaxModulation;
+
+                if (unPackedData.Version < 93)
+                {
+                    Session.Enforced.ShuntBonusResistance = ShuntBonusResistance;
+                    Session.Enforced.ShuntPenResistance = ShuntPenResistance;
+                    Session.Enforced.MaxModulation = MaxModulation;
 
                 if (unPackedData.Version < 92)
                 {

--- a/Data/Scripts/DefenseShields/SupportClasses/StaticUtils.cs
+++ b/Data/Scripts/DefenseShields/SupportClasses/StaticUtils.cs
@@ -104,6 +104,7 @@ namespace DefenseShields.Support
                     Session.Enforced.ShuntBonusResistance = ShuntBonusResistance;
                     Session.Enforced.ShuntPenResistance = ShuntPenResistance;
                     Session.Enforced.MaxModulation = MaxModulation;
+                }
 
                 if (unPackedData.Version < 92)
                 {

--- a/Data/Scripts/DefenseShields/SupportClasses/StaticUtils.cs
+++ b/Data/Scripts/DefenseShields/SupportClasses/StaticUtils.cs
@@ -166,7 +166,10 @@ namespace DefenseShields.Support
                 Session.Enforced.MinHP = MinHP;
                 Session.Enforced.MaxRecharge = MaxRecharge;
                 Session.Enforced.MinRecharge = MinRecharge;
-
+                Session.Enforced.ShuntBonusResistance = ShuntBonusResistance;
+                Session.Enforced.ShuntPenResistance = ShuntPenResistance;
+                Session.Enforced.MaxModulation = MaxModulation;
+                
                 WriteNewConfigFile();
 
                 Log.Line($"wrote new config file - file exists: {MyAPIGateway.Utilities.FileExistsInGlobalStorage("DefenseShields.cfg")}");


### PR DESCRIPTION
These changes allow for directly balancing the damage and bypass resistance granted by shunting, as well as the maximum allowable shield modulation setting.